### PR TITLE
Update frosh-platform-filter-search.plugin.ts

### DIFF
--- a/src/Resources/app/storefront/src/frosh-platform-filter-search/frosh-platform-filter-search.plugin.ts
+++ b/src/Resources/app/storefront/src/frosh-platform-filter-search/frosh-platform-filter-search.plugin.ts
@@ -4,7 +4,7 @@ type HTMLElementEvent<T extends HTMLElement> = Event & {
 
 export default class FroshPlatformSearchFilterPlugin extends window.PluginBaseClass {
     static options = {
-        dropdownSelector: '.filter-panel-items-container .dropdown',
+        dropdownSelector: ".filter-panel-items-container .dropdown"
     };
 
     init() {
@@ -12,50 +12,34 @@ export default class FroshPlatformSearchFilterPlugin extends window.PluginBaseCl
     }
 
     _registerEvents() {
-        this.el.addEventListener('input', this._onInput.bind(this));
-
-        const dropdowns = document.querySelectorAll(this.options.dropdownSelector);
-        if(dropdowns) {
-            dropdowns.forEach((dropdown) => {
-                dropdown.addEventListener('shown.bs.dropdown', this._onDropdownShown.bind(this));
-            });
-        }
+        this.el.addEventListener("input", this._onInput.bind(this));
+        let dropdowns = document.querySelectorAll(this.constructor.options.dropdownSelector);
+        dropdowns && dropdowns.forEach(dropdown => {
+            dropdown.addEventListener("shown.bs.dropdown", this._onDropdownShown.bind(this));
+        });
     }
 
-    _onInput(event: HTMLElementEvent<HTMLInputElement>) {
-        const value = event.target.value.trim().toLowerCase();
-        const dropdown = event.target.closest('.filter-multi-select-dropdown');
-
-        const list = dropdown.querySelector('.filter-multi-select-list');
-        const listItems = list.querySelectorAll('li');
-        const listItemsArray = Array.from(listItems);
-
-        for (const listItem of listItemsArray) {
-            listItem.style.display = 'none';
-            const labelElement = listItem.querySelector( '.filter-multi-select-item-label') as HTMLLabelElement;
-            const label = labelElement.innerText.trim().toLowerCase();
-
-            if (label.includes(value)) {
-                listItem.style.display = null;
+    _onInput(event) {
+        let searchTerm = event.target.value.trim().toLowerCase();
+        let listItems = event.target.closest(".filter-multi-select-dropdown").querySelector(".filter-multi-select-list").querySelectorAll("li");
+        listItems.forEach(item => {
+            item.style.display = "none";
+            let label = item.querySelector(".filter-multi-select-item-label").innerText.trim().toLowerCase();
+            if (label.includes(searchTerm)) {
+                item.style.display = null;
             }
-        }
+        });
     }
 
     _onDropdownShown(event) {
-        const dropdown = event.relatedTarget.closest('.dropdown');
-        const filterInput = dropdown.querySelector('[data-frosh-platform-filter-search=true]');
-
-        if (!filterInput) {
-            return;
-        }
-
-        const dropdownMenu = dropdown.querySelector('.dropdown-menu');
+        let dropdown = event.relatedTarget.closest(".dropdown");
+        if (!dropdown) return;
+        let searchInput = dropdown.querySelector("[data-frosh-platform-filter-search=true]");
+        if (!searchInput) return;
+        let dropdownMenu = dropdown.querySelector(".dropdown-menu");
         if (dropdownMenu) {
-            dropdownMenu.classList.add('fpfs-dropdown-is--expanded');
+            dropdownMenu.classList.add("fpfs-dropdown-is--expanded");
+            searchInput.focus({ preventScroll: true });
         }
-
-        filterInput.focus({
-            preventScroll: true
-        });
     }
 }


### PR DESCRIPTION
The error arised from incorrect syntax used for the static property options. The static keyword is typically used to define static methods or properties within a class. However, in JavaScript, a static property is usually defined outside the class body. Therefore, the use of {} within the static block causes a syntax error.

Closes #18 