### PR TITLE
feat: performance improvement by node replacement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "frosh/platform-filter-search",
     "description": "This plugin inserts a search input above the filter options in the listing.",
     "type": "shopware-platform-plugin",
-    "version": "3.0.1",
+    "version": "3.1.0",
     "authors": [
         {
             "name": "FriendsOfShopware",

--- a/src/Resources/app/storefront/src/frosh-platform-filter-search/frosh-platform-filter-search.plugin.ts
+++ b/src/Resources/app/storefront/src/frosh-platform-filter-search/frosh-platform-filter-search.plugin.ts
@@ -27,18 +27,15 @@ export default class FroshPlatformSearchFilterPlugin extends window.PluginBaseCl
         const dropdown = event.target.closest('.filter-multi-select-dropdown');
 
         const list = dropdown.querySelector('.filter-multi-select-list');
+        const listClone = list.cloneNode(true) as HTMLElement;
+        list.replaceWith(listClone);
         const listItems = list.querySelectorAll('li');
-        const listItemsArray = Array.from(listItems);
-
-        for (const listItem of listItemsArray) {
-            listItem.style.display = 'none';
+        listItems.forEach((listItem) => {
             const labelElement = listItem.querySelector( '.filter-multi-select-item-label') as HTMLLabelElement;
             const label = labelElement.innerText.trim().toLowerCase();
-
-            if (label.includes(value)) {
-                listItem.style.display = null;
-            }
-        }
+            listItem.style.display = label.includes(value) ? null : 'none';
+        });
+        listClone.replaceWith(list);
     }
 
     _onDropdownShown(event) {


### PR DESCRIPTION
closes #23 

Using a node replacement to avoid refreshing updates by the browser when setting display style according to searched entries.

Maintaining event listeners by first cloning the list, replacing original list with clone, changing original lsit in memory non-visible, and then changing node back to original (adjusted) list with event listeners still attached.