### PR TITLE
Update store workflow to use client credentials

### DIFF
--- a/.github/workflows/store.yml
+++ b/.github/workflows/store.yml
@@ -7,6 +7,6 @@ jobs:
     with:
       extensionName: ${{ github.event.repository.name }}
     secrets:
-      accountUser: ${{ secrets.ACCOUNT_USER }}
-      accountPassword: ${{ secrets.ACCOUNT_PASSWORD }}
+      clientId: ${{ secrets.SHOPWARE_CLI_ACCOUNT_CLIENT_ID }}
+      clientSecret: ${{ secrets.SHOPWARE_CLI_ACCOUNT_CLIENT_SECRET }}
       ghToken: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Replace `accountUser` / `accountPassword` secrets with the new `clientId` / `clientSecret` credentials in the store release workflow
- Updates secret references from `ACCOUNT_USER` / `ACCOUNT_PASSWORD` to `SHOPWARE_CLI_ACCOUNT_CLIENT_ID` / `SHOPWARE_CLI_ACCOUNT_CLIENT_SECRET`

This aligns the workflow with the updated `store-release.yml` reusable workflow from `shopware/github-actions`, which now expects client credentials instead of account user/password.